### PR TITLE
[Feature] Support Guzzle7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "SEMrush API client",
     "require": {
         "php": ">=7.1",
-        "guzzlehttp/guzzle": "^6.1",
+        "guzzlehttp/guzzle": "^6.1 | ^7.0",
         "psr/log": "^1.0",
         "psr/simple-cache": "^1.0",
         "silktide/capiture": "^1.2"


### PR DESCRIPTION
It looks like there aren't any relevant BC's for our very basic use of Guzzle in v7

https://github.com/guzzle/guzzle/blob/7.0.0/UPGRADING.md

As such, we should be able to support both v6 and v7.

Should resolve issue #27